### PR TITLE
Fix #219

### DIFF
--- a/src/main/java/doggytalents/block/BlockFoodBowl.java
+++ b/src/main/java/doggytalents/block/BlockFoodBowl.java
@@ -5,7 +5,6 @@ import javax.annotation.Nullable;
 import doggytalents.ModItems;
 import doggytalents.helper.CapabilityHelper;
 import doggytalents.helper.DogUtil;
-import doggytalents.item.ItemTreatBag;
 import doggytalents.tileentity.TileEntityFoodBowl;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockRenderType;
@@ -46,7 +45,7 @@ import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
-import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
 
 public class BlockFoodBowl extends ContainerBlock implements IWaterLoggable {
 
@@ -134,9 +133,9 @@ public class BlockFoodBowl extends ContainerBlock implements IWaterLoggable {
                 ItemStack stack = playerIn.getHeldItem(handIn);
 
                 if(!stack.isEmpty() && stack.getItem() == ModItems.TREAT_BAG) {
-                    ItemStackHandler bagInventory = CapabilityHelper.getOrThrow(stack, ItemTreatBag.TREAT_BAG_CAPABILITY);
+                    IItemHandler bagInventory = CapabilityHelper.getOrThrow(stack, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
                     IItemHandler bowlInventory = CapabilityHelper.getOrThrow(foodBowl, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
-                    DogUtil.transferStacks(bagInventory, bowlInventory);
+                    DogUtil.transferStacks((IItemHandlerModifiable) bagInventory, bowlInventory);
                 } else if(playerIn instanceof ServerPlayerEntity && !(playerIn instanceof FakePlayer)) {
                     ServerPlayerEntity entityPlayerMP = (ServerPlayerEntity)playerIn;
                     NetworkHooks.openGui(entityPlayerMP, foodBowl, posIn);

--- a/src/main/java/doggytalents/entity/EntityDog.java
+++ b/src/main/java/doggytalents/entity/EntityDog.java
@@ -58,9 +58,7 @@ import doggytalents.entity.features.TalentFeature;
 import doggytalents.helper.CapabilityHelper;
 import doggytalents.helper.DogUtil;
 import doggytalents.helper.TalentHelper;
-import doggytalents.item.ItemChewStick;
 import doggytalents.item.ItemFancyCollar;
-import doggytalents.item.ItemTreatBag;
 import doggytalents.lib.ConfigValues;
 import net.minecraft.block.BlockState;
 import net.minecraft.entity.AgeableEntity;
@@ -122,7 +120,8 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.fml.DistExecutor;
-import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
 
 public class EntityDog extends IDogEntity implements IDog {
 
@@ -823,7 +822,7 @@ public class EntityDog extends IDogEntity implements IDog {
 
                     return true;
                 } else if(stack.getItem() == ModItems.TREAT_BAG && this.getDogHunger() < ConfigValues.HUNGER_POINTS && this.canInteract(player) && !this.isIncapacicated()) {
-                    ItemStackHandler treatBag = CapabilityHelper.getOrThrow(stack, ItemTreatBag.TREAT_BAG_CAPABILITY);
+                    IItemHandler treatBag = CapabilityHelper.getOrThrow(stack, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
                     DogUtil.feedDogFrom(this, treatBag);
                     return true;
                 }

--- a/src/main/java/doggytalents/inventory/container/ContainerTreatBag.java
+++ b/src/main/java/doggytalents/inventory/container/ContainerTreatBag.java
@@ -3,26 +3,26 @@ package doggytalents.inventory.container;
 import doggytalents.ModContainerTypes;
 import doggytalents.ModItems;
 import doggytalents.helper.CapabilityHelper;
-import doggytalents.item.ItemTreatBag;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
 import net.minecraft.inventory.container.Container;
 import net.minecraft.inventory.container.Slot;
 import net.minecraft.item.ItemStack;
-import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.CapabilityItemHandler;
+import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
 
 public class ContainerTreatBag extends Container {
 
     public int slot;
     public ItemStack itemstack;
-    public ItemStackHandler bagInventory;
+    public IItemHandler bagInventory;
     
     public ContainerTreatBag(int windowId, PlayerInventory playerInventory, int slotIn, ItemStack itemstackIn) {
         super(ModContainerTypes.TREAT_BAG, windowId);
         this.slot = slotIn;
         this.itemstack = itemstackIn;
-        this.bagInventory = CapabilityHelper.getOrThrow(itemstackIn, ItemTreatBag.TREAT_BAG_CAPABILITY);
+        this.bagInventory = CapabilityHelper.getOrThrow(itemstackIn, CapabilityItemHandler.ITEM_HANDLER_CAPABILITY);
 
         assertInventorySize(playerInventory, 3 * 5);
 


### PR DESCRIPTION
This PR fixes the treat bag item losing items on drop. The bug itself comes from the current usage of `LazyOptional`, creating an item handler outside of the lazy supplier. In addition the current `ItemTreatBag.TREAT_BAG_CAPABILITY` usage is always null, which is certainly not intended and of course not the correct way to use a capability. A `Capability` must always refer to the precise registered type to be successfully injected.

sidenote: appears your previous commit forgot to add the new `IDogFoodItem`/`IDogFedCallback`.