### PR TITLE
Fix food bowl position doesn't reset when it is destoryed

### DIFF
--- a/src/main/java/doggytalents/common/block/FoodBowlBlock.java
+++ b/src/main/java/doggytalents/common/block/FoodBowlBlock.java
@@ -122,6 +122,8 @@ public class FoodBowlBlock extends Block {
                     InventoryHelper.spawnItemStack(worldIn, pos.getX(), pos.getY(), pos.getZ(), bowlInventory.getStackInSlot(i));
                 }
                 worldIn.updateComparatorOutputLevel(pos, this);
+                foodBowl.resetDogRecordBowlPos();
+                foodBowl.clearDogRecord();
             }
 
             super.onReplaced(state, worldIn, pos, newState, isMoving);

--- a/src/main/java/doggytalents/common/block/tileentity/FoodBowlTileEntity.java
+++ b/src/main/java/doggytalents/common/block/tileentity/FoodBowlTileEntity.java
@@ -1,5 +1,7 @@
 package doggytalents.common.block.tileentity;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.List;
 import java.util.UUID;
 
@@ -43,7 +45,8 @@ public class FoodBowlTileEntity extends PlacedTileEntity implements INamedContai
         }
     };
     private final LazyOptional<ItemStackHandler> itemStackHandler = LazyOptional.of(() -> this.inventory);
-
+    private Set<DogEntity> dogRecord = new HashSet<>();
+    
 
     public int timeoutCounter;
 
@@ -77,6 +80,7 @@ public class FoodBowlTileEntity extends PlacedTileEntity implements INamedContai
             UUID placerId = this.getPlacerId();
             if (placerId != null && placerId.equals(dog.getOwnerId()) && !dog.getBowlPos().isPresent()) {
                 dog.setBowlPos(this.pos);
+                dogRecord.add(dog);
             }
 
             if (dog.getDogHunger() < dog.getMaxHunger() / 2) {
@@ -89,6 +93,19 @@ public class FoodBowlTileEntity extends PlacedTileEntity implements INamedContai
 
     public ItemStackHandler getInventory() {
         return this.inventory;
+    }
+
+    public void resetDogRecordBowlPos()
+    {
+        for(DogEntity dog : dogRecord)
+        {
+            dog.setBowlPos(null);
+        }
+    }
+
+    public void clearDogRecord()
+    {
+        dogRecord.clear();
     }
 
     @Nonnull


### PR DESCRIPTION
Related to #270 
Hi, this PR tries to fix the food bowl bug. It will save which dog belongs to this food bowl and reset the dog's food bowl position when the block is replaced.
I am not sure if this is a correct way to fix this. 
I really like this mod and it is really fun, thank you!