### PR TITLE
FIx passive creeper attack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ out
 build
 .gradle
 
+# vscode
+.vscode
+
 # other
 eclipse
 run

--- a/src/main/java/doggytalents/common/entity/ai/BerserkerModeGoal.java
+++ b/src/main/java/doggytalents/common/entity/ai/BerserkerModeGoal.java
@@ -10,7 +10,9 @@ public class BerserkerModeGoal<T extends LivingEntity> extends NearestAttackable
     private final DogEntity dog;
 
     public BerserkerModeGoal(DogEntity dogIn, Class<T> targetClassIn, boolean checkSight) {
-        super(dogIn, targetClassIn, checkSight, false);
+        super(dogIn, targetClassIn, 10, checkSight, false,   //Set the third param to 10 because it is the default param if not specified
+            (target) -> dogIn.wantsToAttack(target, dogIn.getOwner())  //Add predicate whick use the DogEntity::alterations dependent DogEntity::wantsToAttack method to filter out the target
+        );
         this.dog = dogIn;
     }
 

--- a/src/main/java/doggytalents/common/entity/ai/GuardModeGoal.java
+++ b/src/main/java/doggytalents/common/entity/ai/GuardModeGoal.java
@@ -12,7 +12,9 @@ public class GuardModeGoal extends NearestAttackableTargetGoal<MonsterEntity> {
     private LivingEntity owner;
 
     public GuardModeGoal(DogEntity dogIn, boolean checkSight) {
-        super(dogIn, MonsterEntity.class, 0, checkSight, false, null);
+        super(dogIn, MonsterEntity.class, 0, checkSight, false,
+            (target) -> dogIn.wantsToAttack(target, dogIn.getOwner())  //Add predicate whick use the DogEntity::alterations dependent DogEntity::wantsToAttack method to filter out the target
+        );
         this.dog = dogIn;
     }
 


### PR DESCRIPTION
My attempt to fix dog in G Mode and B Mode attacking creeper when they are not supposed to (without CreeperSweeper talent) which is very dangerous for the dog in most cases.
This is a dangerous bug :((( 
Several of my dog's death counts are thanks to this bug .......  :((((

Fix procedure :
- For each goal derived from the NearestAttackableEntityGoal, I set the target predicate to check according to the dog's WantToAttack method which gives the flexibility for the alterations API. I guess that is how it supposed to work .... 

Once again, if I did anything wrong, I am truly sorry, cause I am new ...... 