### PR TITLE
Make G Mode dog also attack with respect to DogEntity::canAttack

### DIFF
--- a/src/main/java/doggytalents/common/entity/ai/GuardModeGoal.java
+++ b/src/main/java/doggytalents/common/entity/ai/GuardModeGoal.java
@@ -42,8 +42,9 @@ public class GuardModeGoal extends NearestAttackableTargetGoal<MonsterEntity> {
         return 6D;
     }
 
+
     @Override
     protected void findTarget() {
-       this.target = this.dog.level.getNearestLoadedEntity(this.targetType, this.targetConditions, this.owner, this.dog.getX(), this.dog.getEyeY(), this.dog.getZ(), this.getTargetSearchArea(this.getFollowDistance()));
+       this.target = this.dog.level.getNearestLoadedEntity(this.targetType, this.targetConditions, this.dog, this.dog.getX(), this.dog.getEyeY(), this.dog.getZ(), this.getTargetSearchArea(this.getFollowDistance()));
     }
 }

--- a/src/main/java/doggytalents/common/entity/ai/GuardModeGoal.java
+++ b/src/main/java/doggytalents/common/entity/ai/GuardModeGoal.java
@@ -42,9 +42,8 @@ public class GuardModeGoal extends NearestAttackableTargetGoal<MonsterEntity> {
         return 6D;
     }
 
-
     @Override
     protected void findTarget() {
-       this.target = this.dog.level.getNearestLoadedEntity(this.targetType, this.targetConditions, this.dog, this.dog.getX(), this.dog.getEyeY(), this.dog.getZ(), this.getTargetSearchArea(this.getFollowDistance()));
+       this.target = this.dog.level.getNearestLoadedEntity(this.targetType, this.targetConditions, this.dog, this.owner.getX(), this.owner.getEyeY(), this.owner.getZ(), this.getTargetSearchArea(this.getFollowDistance()));
     }
 }


### PR DESCRIPTION
 Recently i just created a pull request that has been closed fixing the passive creeper attack. I downloaded the mod and test, the result is great, i know why my fix was overpowering cause i didn't notice that the EntityPredicate already checked based on the DogEntity::canAttack internally...... But still i noticed that an exception is G Mode, after hours of debugging, i am suprised  it is only because the third parameter of the getNearestLoadedEntity got passed in the owner instead, so the check is always based on the owner.......which returns true always...... I wonder why the findTarget function needs to be overrided like that.... cause the only difference is the original function use the getNearbyPlayer  (something like that) for PlayerEntity ...... I am sorry if this is a stupid question, i am just being confused ...... 