### PR TITLE
Make dog and passanger no longer take fall damage when climbing down ladder

### DIFF
--- a/src/main/java/doggytalents/common/entity/DogEntity.java
+++ b/src/main/java/doggytalents/common/entity/DogEntity.java
@@ -2211,6 +2211,10 @@ public class DogEntity extends AbstractDogEntity {
 
                 this.animationSpeed += (f4 - this.animationSpeed) * 0.4F;
                 this.animationPosition += this.animationSpeed;
+
+                if (this.onClimbable()) {
+                    this.fallDistance = 0.0f;
+                }
              } else {
                  this.maxUpStep = 0.5F; // Default
                  this.flyingSpeed = 0.02F; // Default


### PR DESCRIPTION
 solution on issue #334. For now, the onClimbable() check and handle are only present in the client via super::travel(), the server never got to call super::travel() where it checks and handles onClimbable(), only knows and updates the dog's pos, which male it keep increasing DogEntity::fallDistance when the dog down the ladder while you are riding him, which causes unexpected death XD. 