### PR TITLE
Fix DogBed no longer show the owner's name and instead shows its tagged name

### DIFF
--- a/src/main/java/doggytalents/common/block/tileentity/DogBedTileEntity.java
+++ b/src/main/java/doggytalents/common/block/tileentity/DogBedTileEntity.java
@@ -139,7 +139,7 @@ public class DogBedTileEntity extends PlacedTileEntity {
         if (locData != null) {
             ITextComponent text = locData.getName(this.level);
             if (text != null) {
-                this.ownerName = name;
+                this.ownerName = text;
             }
         }
 


### PR DESCRIPTION
On commit 796002f
the "name" local var is removed, which unshadow the "name" identifier, which now pointing to the DogBedTileEntity::name which is meant to represent the name the player tagged the bed with a name tag. The original name var's function has been replaced with the "text" var, which is the correct one