### PR TITLE
Fix player can access any dog's packpuppy inventory

### DIFF
--- a/src/main/java/doggytalents/client/screen/widget/DogInventoryButton.java
+++ b/src/main/java/doggytalents/client/screen/widget/DogInventoryButton.java
@@ -54,7 +54,9 @@ public class DogInventoryButton extends Button {
 
         if (this.visible) {
             Minecraft mc = Minecraft.getInstance();
-            List<DogEntity> dogs = mc.level.getEntitiesOfClass(DogEntity.class, mc.player.getBoundingBox().inflate(12D, 12D, 12D), PackPuppyTalent::hasInventory);
+            List<DogEntity> dogs = mc.level.getEntitiesOfClass(DogEntity.class, mc.player.getBoundingBox().inflate(12D, 12D, 12D), 
+                d -> ( d.canInteract(mc.player) && PackPuppyTalent.hasInventory(d) )
+            );
             this.active = !dogs.isEmpty();
         }
 

--- a/src/main/java/doggytalents/common/network/packet/OpenDogScreenPacket.java
+++ b/src/main/java/doggytalents/common/network/packet/OpenDogScreenPacket.java
@@ -31,8 +31,10 @@ public class OpenDogScreenPacket implements IPacket<OpenDogScreenData>  {
         ctx.get().enqueueWork(() -> {
             if (ctx.get().getDirection().getReceptionSide() == LogicalSide.SERVER) {
                 ServerPlayerEntity player = ctx.get().getSender();
-                List<DogEntity> dogs = player.level.getEntitiesOfClass(DogEntity.class, player.getBoundingBox().inflate(12D, 12D, 12D), PackPuppyTalent::hasInventory);
-                Screens.openDogInventoriesScreen(player, dogs);
+                List<DogEntity> dogs = player.level.getEntitiesOfClass(DogEntity.class, player.getBoundingBox().inflate(12D, 12D, 12D), 
+                    d -> d.canInteract(player) && PackPuppyTalent.hasInventory(d)
+                );
+                if(!dogs.isEmpty()) Screens.openDogInventoriesScreen(player, dogs);
             }
         });
 


### PR DESCRIPTION
So far, as I have been experiencing, the inventory fetch button fetches all nearby dogs with or without their owners' permission. 