### PR TITLE
Only allow leashing if obey other is ok

### DIFF
--- a/src/main/java/doggytalents/common/entity/DogEntity.java
+++ b/src/main/java/doggytalents/common/entity/DogEntity.java
@@ -952,6 +952,12 @@ public class DogEntity extends AbstractDogEntity {
     }
 
     @Override
+    public boolean canBeLeashed(PlayerEntity player) {
+        if(!this.willObeyOthers()) return false;
+        else return super.canBeLeashed(player);
+    }
+
+    @Override
     public void setUUID(UUID uniqueIdIn) {
 
         // If the UUID is changed remove old one and add new one


### PR DESCRIPTION
This prevent other player from leashing your dog without permission.
I prefer to disable leashing when obey other is false anyway because leashing on dog currently make  the a.i becomes really buggy, therefore is discouraged.