### PR TITLE
Fix dog improper dismounting underwater

### DIFF
--- a/src/main/java/doggytalents/common/network/PacketHandler.java
+++ b/src/main/java/doggytalents/common/network/PacketHandler.java
@@ -24,6 +24,7 @@ public final class PacketHandler {
         registerPacket(new DogInventoryPagePacket(), DogInventoryPageData.class);
         registerPacket(new DogTexturePacket(), DogTextureData.class);
         registerPacket(new CritEmitterPacket(), CritEmitterData.class); 
+        registerPacket(new DogDismountPacket(), DogDismountData.class);
     }
 
     public static <MSG> void send(PacketDistributor.PacketTarget target, MSG message) {

--- a/src/main/java/doggytalents/common/network/packet/DogDismountPacket.java
+++ b/src/main/java/doggytalents/common/network/packet/DogDismountPacket.java
@@ -1,0 +1,43 @@
+package doggytalents.common.network.packet;
+
+import java.util.function.Supplier;
+
+import doggytalents.common.entity.DogEntity;
+import doggytalents.common.network.IPacket;
+import doggytalents.common.network.packet.data.DogDismountData;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.world.entity.Entity;
+import net.minecraftforge.network.NetworkEvent.Context;
+
+public class DogDismountPacket implements IPacket<DogDismountData> {
+
+    @Override
+    public void encode(DogDismountData data, FriendlyByteBuf buf) {
+        buf.writeInt(data.dogId);
+    }
+
+    @Override
+    public DogDismountData decode(FriendlyByteBuf buf) {
+        int id = buf.readInt();
+        return new DogDismountData(id);
+    }
+
+    @Override
+    public void handle(DogDismountData data, Supplier<Context> ctx) {
+        ctx.get().enqueueWork(() -> {
+
+            if (ctx.get().getDirection().getReceptionSide().isClient()) { 
+                Minecraft mc = Minecraft.getInstance();
+                Entity e = mc.level.getEntity(data.dogId);
+                if (e instanceof DogEntity d) {
+                    if (d.isPassenger()) d.stopRiding();
+                }
+            }
+
+        });
+
+        ctx.get().setPacketHandled(true);
+    }
+    
+}

--- a/src/main/java/doggytalents/common/network/packet/data/DogDismountData.java
+++ b/src/main/java/doggytalents/common/network/packet/data/DogDismountData.java
@@ -1,0 +1,9 @@
+package doggytalents.common.network.packet.data;
+
+public class DogDismountData {
+    public int dogId;
+
+    public DogDismountData(int id) {
+        this.dogId = id;
+    }
+}

--- a/src/main/java/doggytalents/common/talent/BedFinderTalent.java
+++ b/src/main/java/doggytalents/common/talent/BedFinderTalent.java
@@ -37,7 +37,7 @@ public class BedFinderTalent extends TalentInstance {
                     }
                 }
             } else {
-                dogIn.stopRiding();
+                if (!dogIn.level.isClientSide) dogIn.stopRiding();
                 return InteractionResult.SUCCESS;
             }
         }


### PR DESCRIPTION
When a dog riding a player and the player
enters the water, the dog silently dismount serverside but did not notify the client, this causes the client to still think that the dog is not dismounted and still renders the dog on the player head, thus the dog still has isOrderedToSit == true serverside so even the client sees the dog as if he is still riding and following the owner,  on serverside, the dog was dismounted, stays and float
in the place that he silently dismounted serverside. This causes a bug where the dog suddenly tp back to "nowhere" when the player go somewhere else still having the dog on head after dunking the dog in water, and then dismount the dog then.